### PR TITLE
Migrate to Nexus Mods API for version checks

### DIFF
--- a/VersionChecker/Config.cs
+++ b/VersionChecker/Config.cs
@@ -2,13 +2,13 @@
 using SMLHelper.V2.Options.Attributes;
 using System;
 
-namespace Straitjacket.Utility
+namespace Straitjacket.Utility.VersionChecker
 {
     [Menu("VersionChecker", LoadOn = MenuAttribute.LoadEvents.MenuOpened | MenuAttribute.LoadEvents.MenuRegistered)]
     internal class Config : ConfigFile
     {
         [Choice("Frequency of checks")]
-        public VersionChecker.CheckFrequency Frequency = VersionChecker.CheckFrequency.Hourly;
+        public VersionChecker.CheckFrequency Frequency { get; set; } = VersionChecker.CheckFrequency.Hourly;
 
         public DateTime LastChecked { get; set; }
     }

--- a/VersionChecker/ModJson.cs
+++ b/VersionChecker/ModJson.cs
@@ -32,8 +32,14 @@ namespace Straitjacket.Utility
         /// <summary>
         /// An object containing properties for VersionChecker.
         /// </summary>
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonProperty]
         public VersionCheckerOptions VersionChecker { get; set; } = null;
+
+        /// <summary>
+        /// An object containing Nexus Mods ids for VersionChecker, SAM etc.
+        /// </summary>
+        [JsonProperty]
+        public NexusIdOptions NexusId { get; set; } = null;
 
         /// <summary>
         /// VersionCheckerOptions class describing the properties belonging to the VersionChecker mod.json object.
@@ -46,6 +52,24 @@ namespace Straitjacket.Utility
             /// </summary>
             [JsonRequired]
             public string LatestVersionURL { get; set; }
+        }
+
+        /// <summary>
+        /// NexusIdOptions class describing the properties belonging to the NexusId mod.json object.
+        /// </summary>
+        public class NexusIdOptions
+        {
+            /// <summary>
+            /// Nexus Mods Id for the game on the Subnautica Nexus Mods site.
+            /// </summary>
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public string Subnautica { get; set; } = null;
+
+            /// <summary>
+            /// Nexus Mods Id for the game on the Subnautica: Below Zero Nexus Mods site.
+            /// </summary>
+            [JsonProperty(DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+            public string BelowZero { get; set; } = null;
         }
     }
 }

--- a/VersionChecker/Networking.cs
+++ b/VersionChecker/Networking.cs
@@ -3,6 +3,7 @@ using Oculus.Newtonsoft.Json;
 #elif BELOWZERO
 using Newtonsoft.Json;
 #endif
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -10,41 +11,24 @@ namespace Straitjacket.Utility
 {
     internal class Networking
     {
-        private const string GOOGLE_204_URL = "http://google.com/generate_204";
-        internal static async Task<bool> CheckConnectionAsync(string URL = GOOGLE_204_URL)
-        {
-            if (URL != GOOGLE_204_URL)
-            {
-                var preliminary = await CheckConnectionAsync(GOOGLE_204_URL);
-                if (preliminary)
-                {
-                    return preliminary;
-                }
-            }
-
-            try
-            {
-                using (var client = new WebClient())
-                using (var stream = await client.OpenReadTaskAsync(URL))
-                {
-                    return true;
-                }
-            }
-            catch
-            {
-                return false;
-            }
-        }
-
-        internal static async Task<string> ReadAllTextAsync(string URL)
+        internal static async Task<string> ReadAllTextAsync(string URL, Dictionary<string, string> headers = null)
         {
             using (var client = new WebClient())
             {
+                if (headers != null)
+                {
+                    foreach (var header in headers)
+                    {
+                        client.Headers.Add(header.Key, header.Value);
+                    }
+                }
+
                 return await client.DownloadStringTaskAsync(URL);
             }
         }
 
-        internal static async Task<TJsonObject> ReadJSONAsync<TJsonObject>(string URL) where TJsonObject : class
-            => JsonConvert.DeserializeObject<TJsonObject>(await ReadAllTextAsync(URL));
+        internal static async Task<TJsonObject> ReadJSONAsync<TJsonObject>(string URL, Dictionary<string, string> headers = null)
+            where TJsonObject : class
+            => JsonConvert.DeserializeObject<TJsonObject>(await ReadAllTextAsync(URL, headers));
     }
 }

--- a/VersionChecker/NexusAPI/ModJson.cs
+++ b/VersionChecker/NexusAPI/ModJson.cs
@@ -1,0 +1,29 @@
+﻿#if SUBNAUTICA
+using Oculus.Newtonsoft.Json;
+#elif BELOWZERO
+using Newtonsoft.Json;
+#endif
+
+namespace Straitjacket.Utility.NexusAPI
+{
+    internal class ModJson
+    {
+        [JsonRequired, JsonProperty(PropertyName = "version")]
+        public string Version { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "mod_id")]
+        public int ModId { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "game_id")]
+        public int GameId { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "domain_name")]
+        public string DomainName { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "available")]
+        public bool Available { get; set; }
+    }
+}

--- a/VersionChecker/Properties/AssemblyInfo.cs
+++ b/VersionChecker/Properties/AssemblyInfo.cs
@@ -1,7 +1,7 @@
 ﻿using System.Resources;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Straitjacket.Utility.VersionChecker;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.4.0")]
-[assembly: AssemblyFileVersion("1.1.4.0")]
+[assembly: AssemblyVersion(VersionChecker.Version)]
+[assembly: AssemblyFileVersion(VersionChecker.Version)]
 [assembly: NeutralResourcesLanguage("en-GB")]

--- a/VersionChecker/Straitjacket.Utility.csproj
+++ b/VersionChecker/Straitjacket.Utility.csproj
@@ -80,9 +80,11 @@
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="Networking.cs" />
+    <Compile Include="NexusAPI\ModJson.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ModJson.cs" />
     <Compile Include="VersionChecker.cs" />
+    <Compile Include="VersionCheckerAPI\ModJson.cs" />
     <Compile Include="VersionRecord.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -95,6 +97,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>echo f | xcopy "$(ProjectDir)mod_$(ConfigurationName).json" "$(TargetDir)$(SolutionName)\mod.json" /y
-if exist "E:\Toadbomb\Documents\PowerShell Scripts\Subnautica Modding\post-build.ps1" powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "E:\Toadbomb\Documents\PowerShell Scripts\Subnautica Modding\post-build.ps1" -ProjectName $(SolutionName) -ConfigurationName $(ConfigurationName) -ProjectDir $(ProjectDir) -TargetDir $(TargetDir) -TargetPath $(TargetPath) -CopyXMLs</PostBuildEvent>
+if exist "E:\Toadbomb\Documents\PowerShell Scripts\Subnautica Modding\post-build.ps1" powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "E:\Toadbomb\Documents\PowerShell Scripts\Subnautica Modding\post-build.ps1" -ProjectName $(SolutionName) -ConfigurationName $(ConfigurationName) -ProjectDir $(ProjectDir) -TargetDir $(TargetDir) -TargetPath $(TargetPath) -CopyXMLs -SteamPath foobar</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/VersionChecker/VersionChecker.cs
+++ b/VersionChecker/VersionChecker.cs
@@ -202,7 +202,7 @@ namespace Straitjacket.Utility.VersionChecker
             Logger.LogInfo($"{prefix}Currently running v{qMod.ParsedVersion}.");
         }
 
-        internal static void Check(QModGame game, int modId, IQMod qMod, string URL = null)
+        internal static void Check(QModGame game, uint modId, IQMod qMod, string URL = null)
         {
             GetSingleton();
 
@@ -332,7 +332,6 @@ namespace Straitjacket.Utility.VersionChecker
 
         private delegate string ApiKeyCommand(string apiKey = null);
         private const string VersionCheckerApiKey = "VersionCheckerApiKey";
-        internal const string ApplicationSlug = "Subnautica.VersionChecker";
         internal static string ApiKey;
 
         private string SetApiKey(string apiKey = null)

--- a/VersionChecker/VersionChecker.cs
+++ b/VersionChecker/VersionChecker.cs
@@ -10,13 +10,15 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using Logger = BepInEx.Subnautica.Logger;
 
-namespace Straitjacket.Utility
+namespace Straitjacket.Utility.VersionChecker
 {
     /// <summary>
     /// An API for checking the client is running the latest version of a mod, informing the user if it is not.
     /// </summary>
     public class VersionChecker : MonoBehaviourSingleton<VersionChecker>
     {
+        internal const string Version = "1.2.0.0";
+
         internal enum CheckFrequency
         {
             Startup,
@@ -179,6 +181,7 @@ namespace Straitjacket.Utility
             }
 
             string versionProperty = "Version";
+            PropertyInfo versionPropertyInfo = typeof(ModJson).GetProperty(versionProperty);
 
             var versionRecord = CheckedVersions[qMod] = new VersionRecord
             {
@@ -189,7 +192,6 @@ namespace Straitjacket.Utility
                 CurrentVersion = qMod.ParsedVersion,
                 UpdateAsync = async () =>
                 {
-                    PropertyInfo versionPropertyInfo = typeof(ModJson).GetProperty(versionProperty);
                     if (versionPropertyInfo == null)
                         throw new InvalidOperationException($"Property {versionProperty} not found in type {typeof(ModJson)}");
 
@@ -198,6 +200,79 @@ namespace Straitjacket.Utility
                 }
             };
             Logger.LogInfo($"{prefix}Currently running v{qMod.ParsedVersion}.");
+        }
+
+        internal static void Check(QModGame game, int modId, IQMod qMod, string URL = null)
+        {
+            GetSingleton();
+
+            if (qMod == null)
+                throw new ArgumentNullException("qMod");
+
+            if (CheckedVersions.ContainsKey(qMod))
+                return;
+
+            string prefix = qMod.LoadedAssembly == Assembly.GetAssembly(typeof(VersionChecker))
+                ? string.Empty
+                : $"[{qMod.DisplayName}] ";
+
+            if (qMod.ParsedVersion == null)
+            {
+                Logger.LogError($"{prefix}There was an error retrieving the current version: QModManager failed to parse.");
+                return;
+            }
+
+            string versionProperty = "Version";
+            PropertyInfo versionPropertyInfo = typeof(ModJson).GetProperty(versionProperty);
+
+            var versionRecord = CheckedVersions[qMod] = new VersionRecord
+            {
+                Assembly = qMod.LoadedAssembly,
+                DisplayName = qMod.DisplayName,
+                Colour = GetColour(),
+                CurrentVersion = qMod.ParsedVersion,
+                Game = game,
+                ModId = modId,
+                URL = URL
+            };
+            versionRecord.UpdateAsync = async () =>
+            {
+                string apiKey = string.IsNullOrWhiteSpace(ApiKey)
+                ? (ApiKey = PlayerPrefs.HasKey(VersionCheckerApiKey)
+                    ? PlayerPrefs.GetString(VersionCheckerApiKey)
+                    : null)
+                : ApiKey;
+
+                try
+                {
+                    Version version = await GetLatestVersionAsync(versionRecord, apiKey);
+                    CheckedVersions[qMod].LatestVersion = version;
+                }
+                catch (Exception)
+                {
+                    Version version;
+
+                    if (apiKey != null)
+                    {
+                        try
+                        {
+                            version = await GetLatestVersionAsync(versionRecord);
+                            CheckedVersions[qMod].LatestVersion = version;
+                            return;
+                        }
+                        catch (Exception) { }
+                    }
+
+                    if (URL == null)
+                        throw new InvalidOperationException("Could not retrieve version from Nexus Mods API and no VersionChecker github URL is defined as a fallback.");
+
+                    if (versionPropertyInfo == null)
+                        throw new InvalidOperationException($"Property {versionProperty} not found in type {typeof(ModJson)}");
+
+                    version = await GetLatestVersionAsync<ModJson>(URL, versionPropertyInfo);
+                    CheckedVersions[qMod].LatestVersion = version;
+                }
+            };
         }
 
         internal static async Task<Version> GetLatestVersionAsync(string URL)
@@ -224,6 +299,23 @@ namespace Straitjacket.Utility
             return VersionParser.GetVersion((string)versionPropertyInfo.GetValue(JSON, null));
         }
 
+        internal static async Task<Version> GetLatestVersionAsync(VersionRecord versionRecord, string nexusApiKey = null)
+        {
+            if (nexusApiKey == null)
+            {
+                string url = versionRecord.VersionCheckerAPIModUrl;
+                VersionCheckerAPI.ModJson JSON = await Networking.ReadJSONAsync<VersionCheckerAPI.ModJson>(url);
+                return VersionParser.GetVersion(JSON.Version);
+            }
+            else
+            {
+                string url = versionRecord.NexusAPIModUrl;
+                Dictionary<string, string> headers = new Dictionary<string, string> { ["apikey"] = nexusApiKey };
+                NexusAPI.ModJson JSON = await Networking.ReadJSONAsync<NexusAPI.ModJson>(url, headers);
+                return VersionParser.GetVersion(JSON.Version);
+            }
+        }
+
         internal static Config Config = OptionsPanelHandler.Main.RegisterModOptions<Config>();
 
         /// <summary>
@@ -234,6 +326,40 @@ namespace Straitjacket.Utility
             DontDestroyOnLoad(this);
             SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
             SceneManager.sceneLoaded += SceneManager_sceneLoaded;
+
+            ConsoleCommandsHandler.Main.RegisterConsoleCommand<ApiKeyCommand>("apikey", SetApiKey);
+        }
+
+        private delegate string ApiKeyCommand(string apiKey = null);
+        private const string VersionCheckerApiKey = "VersionCheckerApiKey";
+        internal const string ApplicationSlug = "Subnautica.VersionChecker";
+        internal static string ApiKey;
+
+        private string SetApiKey(string apiKey = null)
+        {
+            if (string.IsNullOrWhiteSpace(apiKey))
+            {
+                if (PlayerPrefs.HasKey(VersionCheckerApiKey))
+                {
+                    apiKey = PlayerPrefs.GetString(VersionCheckerApiKey);
+                    return $"Nexus API key ending in {apiKey.Substring(Math.Max(0, apiKey.Length - 4))} is set.";
+                }
+                else
+                {
+                    return "Nexus API key not set.";
+                }
+            }
+            else if (apiKey.ToLowerInvariant() == "unset")
+            {
+                PlayerPrefs.DeleteKey(VersionCheckerApiKey);
+                return "Nexus API key unset.";
+            }
+            else
+            {
+                PlayerPrefs.SetString(VersionCheckerApiKey, ApiKey = apiKey.Trim());
+                Config.LastChecked = default;
+                return "Nexus API key set.";
+            }
         }
 
         private void OnDestroy() => StopAllCoroutines();
@@ -281,17 +407,18 @@ namespace Straitjacket.Utility
         {
             while (true)
             {
-                Logger.LogDebug("Awaiting next check...");
+                LogDebugs.Add("Awaiting next check...");
                 await ShouldCheckVersionsAsync();
-                Logger.LogDebug("Time to check versions.");
+                LogDebugs.Add("Time to check versions.");
 
                 Config.LastChecked = DateTime.UtcNow;
                 Config.Save();
 
-                Logger.LogInfo("Initiating version checks...");
+                LogInfos.Add("Initiating version checks...");
+
                 IEnumerable<Task> updateRecordTasks = CheckedVersions.Values.Select(x => x.UpdateLatestVersionAsync());
                 await Task.WhenAll(updateRecordTasks);
-                Logger.LogInfo("Version checks complete.");
+                LogInfos.Add("Version checks complete.");
 
                 _ = Task.Run(() => PrintOutdatedVersionsAsync());
             }
@@ -315,11 +442,11 @@ namespace Straitjacket.Utility
             switch (versionRecord.State)
             {
                 case VersionRecord.VersionState.Outdated:
-                    Logger.LogWarning($"{prefix}{versionRecord.Message(false)}");
+                    LogWarnings.Add($"{prefix}{versionRecord.Message(false)}");
 
                     for (var i = 0; i < 3; i++)
                     {
-                        messages.Add($"[<color=#{ColorUtility.ToHtmlStringRGB(versionRecord.Colour)}>" +
+                        displayMessages.Add($"[<color=#{ColorUtility.ToHtmlStringRGB(versionRecord.Colour)}>" +
                             $"{versionRecord.DisplayName}</color>] {versionRecord.Message(true)}");
 
                         if (i < 2)
@@ -327,26 +454,70 @@ namespace Straitjacket.Utility
                     }
                     break;
                 case VersionRecord.VersionState.Unknown:
-                    Logger.LogWarning($"{prefix}{versionRecord.Message(false)}");
+                    LogWarnings.Add($"{prefix}{versionRecord.Message(false)}");
                     break;
                 case VersionRecord.VersionState.Ahead:
                 case VersionRecord.VersionState.Current:
                 default:
-                    Logger.LogMessage($"{prefix}{versionRecord.Message(false)}");
+                    LogMessages.Add($"{prefix}{versionRecord.Message(false)}");
                     break;
             }
         }
 
-        private List<string> messages = new List<string>();
+        internal List<string> LogDebugs = new List<string>();
+        internal List<string> LogInfos = new List<string>();
+        internal List<string> LogMessages = new List<string>();
+        internal List<string> LogWarnings = new List<string>();
+        internal List<string> LogErrors = new List<string>();
+        private List<string> displayMessages = new List<string>();
         private void Update()
         {
-            if (messages.Any())
+            if (displayMessages.Any())
             {
-                foreach (var message in messages)
-                {
+                foreach (var message in displayMessages)
                     ErrorMessage.AddError(message);
-                }
-                messages.Clear();
+
+                displayMessages.Clear();
+            }
+
+            if (LogDebugs.Any())
+            {
+                foreach (var debug in LogDebugs)
+                    Logger.LogDebug(debug);
+
+                LogDebugs.Clear();
+            }
+
+            if (LogInfos.Any())
+            {
+                foreach (var info in LogInfos)
+                    Logger.LogInfo(info);
+
+                LogInfos.Clear();
+            }
+
+            if (LogMessages.Any())
+            {
+                foreach (var message in LogMessages)
+                    Logger.LogMessage(message);
+
+                LogMessages.Clear();
+            }
+
+            if (LogWarnings.Any())
+            {
+                foreach (var warning in LogWarnings)
+                    Logger.LogWarning(warning);
+
+                LogWarnings.Clear();
+            }
+
+            if (LogErrors.Any())
+            {
+                foreach (var error in LogErrors)
+                    Logger.LogError(error);
+
+                LogErrors.Clear();
             }
         }
 

--- a/VersionChecker/VersionChecker.cs
+++ b/VersionChecker/VersionChecker.cs
@@ -312,7 +312,12 @@ namespace Straitjacket.Utility.VersionChecker
                 string url = versionRecord.NexusAPIModUrl;
                 Dictionary<string, string> headers = new Dictionary<string, string> { ["apikey"] = nexusApiKey };
                 NexusAPI.ModJson JSON = await Networking.ReadJSONAsync<NexusAPI.ModJson>(url, headers);
-                return VersionParser.GetVersion(JSON.Version);
+
+                if (JSON.Available)
+                    return VersionParser.GetVersion(JSON.Version);
+                else    // if the mod is unavailable on nexus mods, return the current version so the user is not constantly
+                        // bugged to update a mod they can't access
+                    return versionRecord.CurrentVersion;
             }
         }
 

--- a/VersionChecker/VersionCheckerAPI/ModJson.cs
+++ b/VersionChecker/VersionCheckerAPI/ModJson.cs
@@ -1,0 +1,29 @@
+﻿#if SUBNAUTICA
+using Oculus.Newtonsoft.Json;
+#elif BELOWZERO
+using Newtonsoft.Json;
+#endif
+
+namespace Straitjacket.Utility.VersionCheckerAPI
+{
+    internal class ModJson
+    {
+        [JsonRequired, JsonProperty(PropertyName = "mod_id")]
+        public int ModId { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "game_id")]
+        public int GameId { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "name")]
+        public string Name { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "version")]
+        public string Version { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "status")]
+        public string Status { get; set; }
+
+        [JsonRequired, JsonProperty(PropertyName = "available")]
+        public bool Available { get; set; }
+    }
+}

--- a/VersionChecker/VersionRecord.cs
+++ b/VersionChecker/VersionRecord.cs
@@ -23,7 +23,7 @@ namespace Straitjacket.Utility.VersionChecker
         public Version CurrentVersion;
         public Version LatestVersion;
         public QModGame Game = QModGame.None;
-        public int ModId;
+        public uint ModId;
         public Func<Task> UpdateAsync;
 
         public string NexusDomainName => Game switch

--- a/VersionChecker/mod_BELOWZERO.json
+++ b/VersionChecker/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "VersionChecker",
     "DisplayName": "VersionChecker",
     "Author": "Tobey Blaber",
-    "Version": "1.1.4",
+    "Version": "1.2",
     "AssemblyName": "Straitjacket.Utility.VersionChecker.dll",
     "Enable": true,
     "Game": "BelowZero",
@@ -11,5 +11,8 @@
     },
     "VersionChecker": {
         "LatestVersionURL": "https://github.com/tobeyStraitjacket/VersionChecker/raw/master/VersionChecker/mod_BELOWZERO.json"
+    },
+    "NexusId": {
+        "BelowZero": "66"
     }
 }

--- a/VersionChecker/mod_SUBNAUTICA.json
+++ b/VersionChecker/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "VersionChecker",
     "DisplayName": "VersionChecker",
     "Author": "Tobey Blaber",
-    "Version": "1.1.4",
+    "Version": "1.2",
     "AssemblyName": "Straitjacket.Utility.VersionChecker.dll",
     "Enable": true,
     "Game": "Subnautica",
@@ -11,5 +11,8 @@
     },
     "VersionChecker": {
         "LatestVersionURL": "https://github.com/tobeyStraitjacket/VersionChecker/raw/master/VersionChecker/mod_SUBNAUTICA.json"
+    },
+    "NexusId": {
+        "Subnautica": "467"
     }
 }


### PR DESCRIPTION
- Make use of `NexusId` property in `mod.json` when available:
  - Use provided API key when possible
  - If no API key provided, use VersionChecker proxy API instead
- If failed or no `NexusId` property, fall back to `VersionChecker` property instead