### PR TITLE
VersionChecker 1.2.2

### DIFF
--- a/VersionChecker/Straitjacket.Utility.csproj
+++ b/VersionChecker/Straitjacket.Utility.csproj
@@ -95,6 +95,6 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>echo f | xcopy "$(ProjectDir)mod_$(ConfigurationName).json" "$(TargetDir)$(SolutionName)\mod.json" /y
-if exist "E:\Toadbomb\Documents\PowerShell Scripts\Subnautica Modding\post-build.ps1" powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "E:\Toadbomb\Documents\PowerShell Scripts\Subnautica Modding\post-build.ps1" -ProjectName $(SolutionName) -ConfigurationName $(ConfigurationName) -ProjectDir $(ProjectDir) -TargetDir $(TargetDir) -TargetPath $(TargetPath) -SteamPath foobar</PostBuildEvent>
+if exist "E:\Toadbomb\Documents\PowerShell Scripts\Subnautica Modding\post-build.ps1" powershell.exe -ExecutionPolicy Bypass -NoProfile -NonInteractive -File "E:\Toadbomb\Documents\PowerShell Scripts\Subnautica Modding\post-build.ps1" -ProjectName $(SolutionName) -ConfigurationName $(ConfigurationName) -ProjectDir $(ProjectDir) -TargetDir $(TargetDir) -TargetPath $(TargetPath)</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/VersionChecker/VersionChecker.cs
+++ b/VersionChecker/VersionChecker.cs
@@ -63,6 +63,9 @@ namespace Straitjacket.Utility.VersionChecker
                 CurrentVersion = qMod.ParsedVersion,
                 UpdateAsync = async () =>
                 {
+                    if (!qMod.IsLoaded)
+                        return;
+
                     if (versionPropertyInfo == null)
                         throw new InvalidOperationException($"Property {versionProperty} not found in type {typeof(ModJson)}");
 
@@ -108,6 +111,9 @@ namespace Straitjacket.Utility.VersionChecker
             };
             versionRecord.UpdateAsync = async () =>
             {
+                if (!qMod.IsLoaded)
+                    return;
+
                 string apiKey = string.IsNullOrWhiteSpace(ApiKey)
                 ? (ApiKey = PlayerPrefs.HasKey(VersionCheckerApiKey)
                     ? PlayerPrefs.GetString(VersionCheckerApiKey)

--- a/VersionChecker/VersionChecker.cs
+++ b/VersionChecker/VersionChecker.cs
@@ -247,12 +247,9 @@ namespace Straitjacket.Utility.VersionChecker
         {
             if (Main != null && !Main.IsRunning)
             {
-                if (scene.name == "StartScreen")
-                {
-                    Main.IsRunning = true;
-                    _ = Main.CheckVersionsAsyncLoop();
-                    SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
-                }
+                Main.IsRunning = true;
+                _ = Main.CheckVersionsAsyncLoop();
+                SceneManager.sceneLoaded -= SceneManager_sceneLoaded;
             }
         }
 

--- a/VersionChecker/VersionChecker.cs
+++ b/VersionChecker/VersionChecker.cs
@@ -14,7 +14,7 @@ namespace Straitjacket.Utility.VersionChecker
 {
     internal class VersionChecker : MonoBehaviourSingleton<VersionChecker>
     {
-        internal const string Version = "1.2.1.0";
+        internal const string Version = "1.2.2.0";
 
         internal enum CheckFrequency
         {

--- a/VersionChecker/mod_BELOWZERO.json
+++ b/VersionChecker/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "VersionChecker",
     "DisplayName": "VersionChecker",
     "Author": "Tobey Blaber",
-    "Version": "1.2.1",
+    "Version": "1.2.2",
     "AssemblyName": "Straitjacket.Utility.VersionChecker.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/VersionChecker/mod_SUBNAUTICA.json
+++ b/VersionChecker/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "VersionChecker",
     "DisplayName": "VersionChecker",
     "Author": "Tobey Blaber",
-    "Version": "1.2.1",
+    "Version": "1.2.2",
     "AssemblyName": "Straitjacket.Utility.VersionChecker.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
## Changes in this version
- HOTFIX: Fixes a bug when VersionChecker tasks were never getting started due to the main menu scene having changed.
- We now skip checking versions for QMods which are not loaded #14 