### PR TITLE
Include QModManager in version checks

### DIFF
--- a/VersionChecker/Main.cs
+++ b/VersionChecker/Main.cs
@@ -31,6 +31,16 @@ namespace Straitjacket.Utility.VersionChecker
             Logger.LogInfo("Initialising...");
             var stopwatch = Stopwatch.StartNew();
 
+            InitializeVersionCheckerVersionChecks();
+            InitialiseQModManagerVersionChecks();
+            InitialiseQModVersionChecks();
+
+            stopwatch.Stop();
+            Logger.LogInfo($"Initialised in {stopwatch.ElapsedMilliseconds}ms.");
+        }
+
+        private static void InitializeVersionCheckerVersionChecks()
+        {
 #if SUBNAUTICA
             var url = "https://github.com/tobeyStraitjacket/VersionChecker/raw/master/VersionChecker/mod_SUBNAUTICA.json";
             VersionChecker.Check(QModGame.Subnautica, 467, QModServices.Main.GetMyMod(), url);
@@ -38,7 +48,19 @@ namespace Straitjacket.Utility.VersionChecker
             var url = "https://github.com/tobeyStraitjacket/VersionChecker/raw/master/VersionChecker/mod_BELOWZERO.json";
             VersionChecker.Check(QModGame.BelowZero, 66, QModServices.Main.GetMyMod(), url);
 #endif
+        }
 
+        private static void InitialiseQModManagerVersionChecks()
+        {
+#if SUBNAUTICA
+            VersionChecker.Check(QModGame.Subnautica, 201, new QModManagerQMod());
+#elif BELOWZERO
+            VersionChecker.Check(QModGame.BelowZero, 1, new QModManagerQMod());
+#endif
+        }
+
+        private static void InitialiseQModVersionChecks()
+        {
             var QModsPath = Path.Combine(Environment.CurrentDirectory, "QMods");
             var subfolders = Directory.GetDirectories(QModsPath, "*", SearchOption.TopDirectoryOnly);
 
@@ -112,9 +134,6 @@ namespace Straitjacket.Utility.VersionChecker
                     }
                 }
             }
-
-            stopwatch.Stop();
-            Logger.LogInfo($"Initialised in {stopwatch.ElapsedMilliseconds}ms.");
         }
     }
 }

--- a/VersionChecker/QModManagerQMod.cs
+++ b/VersionChecker/QModManagerQMod.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using QModManager.API;
+
+namespace Straitjacket.Utility
+{
+    internal class QModManagerQMod : IQMod
+    {
+        public string Id { get; } = "QModManager";
+
+        public string DisplayName { get; } = "QModManager";
+
+        public string Author => throw new NotImplementedException();
+
+        public QModGame SupportedGame { get; }
+#if SUBNAUTICA
+            = QModGame.Subnautica;
+#elif BELOWZERO
+            = QModGame.BelowZero;
+#endif
+
+        public IEnumerable<RequiredQMod> RequiredMods => throw new NotImplementedException();
+
+        public IEnumerable<string> ModsToLoadBefore => throw new NotImplementedException();
+
+        public IEnumerable<string> ModsToLoadAfter => throw new NotImplementedException();
+
+        public Assembly LoadedAssembly { get; } = Assembly.GetAssembly(typeof(IQMod));
+
+        public string AssemblyName => throw new NotImplementedException();
+
+        public Version ParsedVersion => LoadedAssembly.GetName().Version;
+
+        public bool Enable { get; } = true;
+
+        public bool IsLoaded { get; } = true;
+    }
+}

--- a/VersionChecker/QModManagerQMod.cs
+++ b/VersionChecker/QModManagerQMod.cs
@@ -14,7 +14,7 @@ namespace Straitjacket.Utility
 
         public string DisplayName { get; } = "QModManager";
 
-        public string Author => throw new NotImplementedException();
+        public string Author { get; } = "QModManager";
 
         public QModGame SupportedGame { get; }
 #if SUBNAUTICA
@@ -23,15 +23,15 @@ namespace Straitjacket.Utility
             = QModGame.BelowZero;
 #endif
 
-        public IEnumerable<RequiredQMod> RequiredMods => throw new NotImplementedException();
+        public IEnumerable<RequiredQMod> RequiredMods { get; } = new RequiredQMod[0];
 
-        public IEnumerable<string> ModsToLoadBefore => throw new NotImplementedException();
+        public IEnumerable<string> ModsToLoadBefore { get; } = new string[0];
 
-        public IEnumerable<string> ModsToLoadAfter => throw new NotImplementedException();
+        public IEnumerable<string> ModsToLoadAfter { get; } = new string[0];
 
         public Assembly LoadedAssembly { get; } = Assembly.GetAssembly(typeof(IQMod));
 
-        public string AssemblyName => throw new NotImplementedException();
+        public string AssemblyName => LoadedAssembly.GetName().Name;
 
         public Version ParsedVersion => LoadedAssembly.GetName().Version;
 

--- a/VersionChecker/Straitjacket.Utility.csproj
+++ b/VersionChecker/Straitjacket.Utility.csproj
@@ -81,6 +81,7 @@
     <Compile Include="NexusAPI\ModJson.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ModJson.cs" />
+    <Compile Include="QModManagerQMod.cs" />
     <Compile Include="VersionChecker.cs" />
     <Compile Include="VersionCheckerAPI\ModJson.cs" />
     <Compile Include="VersionRecord.cs" />


### PR DESCRIPTION
Adds a `QModManagerQMod` as an `IQMod` implementation specifically for emulating a `QMod` manifest for QModManager itself, and passes this to through to `VersionChecker.Check` as if it were a QMod.

Result: QModManager is added to the checks performed by VersionChecker.