### PR TITLE
VersionChecker 1.3.0.1

### DIFF
--- a/VersionChecker/Main.cs
+++ b/VersionChecker/Main.cs
@@ -75,9 +75,19 @@ namespace Straitjacket.Utility.VersionChecker
                     {
                         var modJson = JsonConvert.DeserializeObject<ModJson>(File.ReadAllText(modJsonPath));
                         if (!modJson.Enable)
+                        {
+                            Logger.LogInfo($"Skipping disabled mod: {modJson.DisplayName}");
                             continue;
+                        }
+
 
                         IQMod qMod = QModServices.Main.FindModById(modJson.Id);
+                        if (qMod is null)
+                        {
+                            Logger.LogWarning($"Skipping mod due to QModServices error: {modJson.DisplayName}.");
+                            continue;
+                        }
+
                         if (modJson.NexusId != null && (modJson.NexusId.Subnautica != null || modJson.NexusId.BelowZero != null))
                         {
                             QModGame game = Paths.ProcessName switch

--- a/VersionChecker/Main.cs
+++ b/VersionChecker/Main.cs
@@ -74,11 +74,10 @@ namespace Straitjacket.Utility.VersionChecker
                     try
                     {
                         var modJson = JsonConvert.DeserializeObject<ModJson>(File.ReadAllText(modJsonPath));
-                        IQMod qMod = QModServices.Main.FindModById(modJson.Id);
-
-                        if (!qMod.Enable)
+                        if (!modJson.Enable)
                             continue;
 
+                        IQMod qMod = QModServices.Main.FindModById(modJson.Id);
                         if (modJson.NexusId != null && (modJson.NexusId.Subnautica != null || modJson.NexusId.BelowZero != null))
                         {
                             QModGame game = Paths.ProcessName switch

--- a/VersionChecker/ModJson.cs
+++ b/VersionChecker/ModJson.cs
@@ -30,6 +30,12 @@ namespace Straitjacket.Utility
         public string Id { get; set; }
 
         /// <summary>
+        /// Whether the mod is enabled.
+        /// </summary>
+        [JsonProperty]
+        public bool Enable { get; set; } = true;
+
+        /// <summary>
         /// An object containing properties for VersionChecker.
         /// </summary>
         [JsonProperty]

--- a/VersionChecker/VersionChecker.cs
+++ b/VersionChecker/VersionChecker.cs
@@ -14,7 +14,7 @@ namespace Straitjacket.Utility.VersionChecker
 {
     internal class VersionChecker : MonoBehaviourSingleton<VersionChecker>
     {
-        internal const string Version = "1.3.0.0";
+        internal const string Version = "1.3.0.1";
 
         internal enum CheckFrequency
         {

--- a/VersionChecker/mod_BELOWZERO.json
+++ b/VersionChecker/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "VersionChecker",
     "DisplayName": "VersionChecker",
     "Author": "Tobey Blaber",
-    "Version": "1.3",
+    "Version": "1.3.0.1",
     "AssemblyName": "Straitjacket.Utility.VersionChecker.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/VersionChecker/mod_SUBNAUTICA.json
+++ b/VersionChecker/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "VersionChecker",
     "DisplayName": "VersionChecker",
     "Author": "Tobey Blaber",
-    "Version": "1.3",
+    "Version": "1.3.0.1",
     "AssemblyName": "Straitjacket.Utility.VersionChecker.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
## Changes in this release
- Fixes a `NullReferenceException` that occurred when parsing disabled mods. #18 