### PR TITLE
Send the mod's display name to the API for improved server-side logging

### DIFF
--- a/VersionChecker/VersionChecker.cs
+++ b/VersionChecker/VersionChecker.cs
@@ -25,7 +25,7 @@ namespace Straitjacket.Utility.VersionChecker
 
         private delegate string ApiKeyCommand(string apiKey = null);
 
-        public const string Version = "1.3.0.1";
+        public const string Version = "1.3.0.2";
         private const string VersionCheckerApiKey = "VersionCheckerApiKey";
 
         private static string apiKey;

--- a/VersionChecker/VersionRecord.cs
+++ b/VersionChecker/VersionRecord.cs
@@ -49,6 +49,7 @@ namespace Straitjacket.Utility.VersionChecker
 
         public Assembly Assembly => QMod.LoadedAssembly;
         public string DisplayName => QMod.DisplayName;
+        private string DisplayNameEncoded => WebUtility.UrlEncode(DisplayName);
 
         private Color? colour;
         public Color Colour => colour ??= GetColour();
@@ -58,6 +59,7 @@ namespace Straitjacket.Utility.VersionChecker
         public Version LatestVersion { get; private set; }
         public QModGame Game { get; set; } = QModGame.None;
         public uint ModId { get; }
+        private string ModIdEncoded => WebUtility.UrlEncode(ModId.ToString());
 
         public string NexusDomainName => Game switch
         {
@@ -70,7 +72,7 @@ namespace Straitjacket.Utility.VersionChecker
             : $"https://api.nexusmods.com/v1/games/{NexusDomainName}/mods/{ModId}.json";
         public string VersionCheckerAPIModUrl => Game == QModGame.None || ModId == 0
             ? null
-            : $"https://mods.vc.api.straitjacket.software/v1/games/{NexusDomainName}/mods/{ModId}/{DisplayName}.json";
+            : $"https://mods.vc.api.straitjacket.software/v1/games/{NexusDomainName}/mods/{ModIdEncoded}/{DisplayNameEncoded}.json";
 
         public VersionState State => CurrentVersion switch
         {

--- a/VersionChecker/VersionRecord.cs
+++ b/VersionChecker/VersionRecord.cs
@@ -70,7 +70,7 @@ namespace Straitjacket.Utility.VersionChecker
             : $"https://api.nexusmods.com/v1/games/{NexusDomainName}/mods/{ModId}.json";
         public string VersionCheckerAPIModUrl => Game == QModGame.None || ModId == 0
             ? null
-            : $"https://mods.vc.api.straitjacket.software/v1/games/{NexusDomainName}/mods/{ModId}.json";
+            : $"https://mods.vc.api.straitjacket.software/v1/games/{NexusDomainName}/mods/{ModId}/{DisplayName}.json";
 
         public VersionState State => CurrentVersion switch
         {

--- a/VersionChecker/mod_BELOWZERO.json
+++ b/VersionChecker/mod_BELOWZERO.json
@@ -2,7 +2,7 @@
     "Id": "VersionChecker",
     "DisplayName": "VersionChecker",
     "Author": "Tobey Blaber",
-    "Version": "1.3.0.1",
+    "Version": "1.3.0.2",
     "AssemblyName": "Straitjacket.Utility.VersionChecker.dll",
     "Enable": true,
     "Game": "BelowZero",

--- a/VersionChecker/mod_SUBNAUTICA.json
+++ b/VersionChecker/mod_SUBNAUTICA.json
@@ -2,7 +2,7 @@
     "Id": "VersionChecker",
     "DisplayName": "VersionChecker",
     "Author": "Tobey Blaber",
-    "Version": "1.3.0.1",
+    "Version": "1.3.0.2",
     "AssemblyName": "Straitjacket.Utility.VersionChecker.dll",
     "Enable": true,
     "Game": "Subnautica",


### PR DESCRIPTION
Simply enables us to more easily track down mods which have incorrect nexus ids set in their `mod.json` file so that we can report this to the mod author and ask them nicely to update it :)

Also adds url encoding of the strings which are passed to us from the `mod.json` before sending them across the wire.