### PR TITLE
Where possible, add the parsed display name to the error log

### DIFF
--- a/VersionChecker/Main.cs
+++ b/VersionChecker/Main.cs
@@ -115,17 +115,17 @@ namespace Straitjacket.Utility.VersionChecker
                             }
                             catch (ArgumentNullException e)
                             {
-                                Logger.LogError($"Skipping NexusId: mod ID is null: {modIdString}");
+                                Logger.LogError($"[{modJson.DisplayName}] Skipping NexusId: mod ID is null: {modIdString}");
                                 Logger.LogError(e.Message);
                             }
                             catch (FormatException e)
                             {
-                                Logger.LogError($"Skipping NexusId: mod ID is not a valid unsigned integer: {modIdString}");
+                                Logger.LogError($"[{modJson.DisplayName}] Skipping NexusId: mod ID is not a valid unsigned integer: {modIdString}");
                                 Logger.LogError(e.Message);
                             }
                             catch (OverflowException e)
                             {
-                                Logger.LogError($"Skipping NexusId: mod ID is outside the valid range for an unsigned integer: " +
+                                Logger.LogError($"[{modJson.DisplayName}] Skipping NexusId: mod ID is outside the valid range for an unsigned integer: " +
                                     $"{modIdString}");
                                 Logger.LogError(e.Message);
                             }


### PR DESCRIPTION
To make it easier to track down mods which don't have the mod ID set correctly and debug issues with parsing the json, wherever possible we should include the mod's display name in the error log.